### PR TITLE
Update selectors

### DIFF
--- a/tests/test_selectors34.py
+++ b/tests/test_selectors34.py
@@ -2,6 +2,7 @@ import errno
 import random
 import signal
 import socket
+import sys
 from time import sleep
 try:
     import unittest2 as unittest
@@ -168,14 +169,17 @@ class BaseSelectorTestCase(object):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
+        mapping = s.get_map()
         rd, wr = self.make_socketpair()
 
         s.register(rd, selectors.EVENT_READ)
         s.register(wr, selectors.EVENT_WRITE)
 
         s.close()
-        self.assertRaises(KeyError, s.get_key, rd)
-        self.assertRaises(KeyError, s.get_key, wr)
+        self.assertRaises(RuntimeError, s.get_key, rd)
+        self.assertRaises(RuntimeError, s.get_key, wr)
+        self.assertRaises(KeyError, mapping.__getitem__, rd)
+        self.assertRaises(KeyError, mapping.__getitem__, wr)
 
     def test_get_key(self):
         s = self.SELECTOR()
@@ -242,8 +246,8 @@ class BaseSelectorTestCase(object):
             sel.register(rd, selectors.EVENT_READ)
             sel.register(wr, selectors.EVENT_WRITE)
 
-        self.assertRaises(KeyError, s.get_key, rd)
-        self.assertRaises(KeyError, s.get_key, wr)
+        self.assertRaises(RuntimeError, s.get_key, rd)
+        self.assertRaises(RuntimeError, s.get_key, wr)
 
     def test_fileno(self):
         s = self.SELECTOR()
@@ -307,6 +311,15 @@ class BaseSelectorTestCase(object):
 
         self.assertEqual(bufs, [MSG] * NUM_SOCKETS)
 
+    @unittest.skipIf(sys.platform == 'win32',
+                     'select.select() cannot be used with empty fd sets')
+    def test_empty_select(self):
+        # Issue #23009: Make sure EpollSelector.select() works when no FD is
+        # registered.
+        s = self.SELECTOR()
+        self.addCleanup(s.close)
+        self.assertEqual(s.select(timeout=0), [])
+
     def test_timeout(self):
         s = self.SELECTOR()
         self.addCleanup(s.close)
@@ -330,11 +343,40 @@ class BaseSelectorTestCase(object):
         self.assertFalse(s.select(1))
         t1 = time()
         dt = t1 - t0
-        self.assertTrue(0.8 <= dt <= 1.6, dt)
+        # Tolerate 2.0 seconds for very slow buildbots
+        self.assertTrue(0.8 <= dt <= 2.0, dt)
 
     @unittest.skipUnless(hasattr(signal, "alarm"),
                          "signal.alarm() required for this test")
-    def test_select_interrupt(self):
+    def test_select_interrupt_exc(self):
+        s = self.SELECTOR()
+        self.addCleanup(s.close)
+
+        rd, wr = self.make_socketpair()
+
+        class InterruptSelect(Exception):
+            pass
+
+        def handler(*args):
+            raise InterruptSelect
+
+        orig_alrm_handler = signal.signal(signal.SIGALRM, handler)
+        self.addCleanup(signal.signal, signal.SIGALRM, orig_alrm_handler)
+        self.addCleanup(signal.alarm, 0)
+
+        signal.alarm(1)
+
+        s.register(rd, selectors.EVENT_READ)
+        t = time()
+        # select() is interrupted by a signal which raises an exception
+        with self.assertRaises(InterruptSelect):
+            s.select(30)
+        # select() was interrupted before the timeout of 30 seconds
+        self.assertLess(time() - t, 5.0)
+
+    @unittest.skipUnless(hasattr(signal, "alarm"),
+                         "signal.alarm() required for this test")
+    def test_select_interrupt_noraise(self):
         s = self.SELECTOR()
         self.addCleanup(s.close)
 
@@ -348,11 +390,14 @@ class BaseSelectorTestCase(object):
 
         s.register(rd, selectors.EVENT_READ)
         t = time()
-        self.assertFalse(s.select(2))
-        self.assertLess(time() - t, 2.5)
+        # select() is interrupted by a signal, but the signal handler doesn't
+        # raise an exception, so select() should by retries with a recomputed
+        # timeout
+        self.assertFalse(s.select(1.5))
+        self.assertGreaterEqual(time() - t, 1.0)
 
 
-class ScalableSelectorMixIn:
+class ScalableSelectorMixIn(object):
 
     # see issue #18963 for why it's skipped on older OS X versions
     @support.requires_mac_ver(10, 5)

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,5 @@ commands = py.test tests/
 deps =
   pytest
   py26: unittest2
-  py2{6,7}: mock
+  py26: mock==1.0.1
+  py27: mock


### PR DESCRIPTION
Hi,

I would like to use selectors34 in my Trollius project, but it looks like selectors.py in trollius is more up to date, than selectors34.

This pull request retrieves the 3 latest major changes in selectors.py. It fixes also Python 2.6 support (broken recently by the release of mock 1.1).
