### PR TITLE
Fix for gevent's patched select problem

### DIFF
--- a/selectors34.py
+++ b/selectors34.py
@@ -324,7 +324,7 @@ class SelectSelector(_BaseSelectorImpl):
             r, w, x = select.select(r, w, w, timeout)
             return r, w + x, []
     else:
-        _select = select.select
+        _select = staticmethod(select.select)
 
     def select(self, timeout=None):
         timeout = None if timeout is None else max(timeout, 0)


### PR DESCRIPTION
Without this fix module fails miserably when used with `gevent` monkey-patching. 

This code snippet

``` python
from gevent.monkey import patch_all
patch_all()

import selectors34 as selectors

s = selectors.SelectSelector()
s.select(0)
```

results in

```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    s.select(0)
  File "/Users/czajnik/Library/Python/2.7/lib/python/site-packages/selectors34.py", line 425, in select
    self._readers, self._writers, [], timeout)
  File "/Users/czajnik/Library/Python/2.7/lib/python/site-packages/selectors34.py", line 111, in wrap_error
    return func(*args, **kw)
TypeError: select() takes at most 4 arguments (5 given)
```

This is because monkey-patching replaces `select.select()` (which is a built-in function by default) with a regular function, which gets converted into unbound method here: 

``` python
_select = select.select
```

This conversion doesn't happen for built-ins, that's why it works without monkey-patching.
